### PR TITLE
🐛fix(datePicker): Remove month jumps in date picker

### DIFF
--- a/src/DateField.js
+++ b/src/DateField.js
@@ -203,7 +203,7 @@ export default class DateField extends React.Component {
         displayed.getMonth() === 0
           ? 11
           : displayed.getMonth() - 1,
-        displayed.getDate()
+        1
       ),
     });
   }
@@ -221,7 +221,7 @@ export default class DateField extends React.Component {
         displayed.getMonth() === 11
           ? 0
           : displayed.getMonth() + 1,
-        displayed.getDate()
+        1
       ),
     });
   }

--- a/tests/DateField.test.js
+++ b/tests/DateField.test.js
@@ -72,7 +72,7 @@ describe('<DateField />', () => {
     expect(value).toBeDefined();
     expect(value.getFullYear()).toBe(1995);
     expect(value.getMonth()).toBe(10);
-    expect(value.getDate()).toBe(17);
+    expect(value.getDate()).toBe(1);
   });
 
   it('should jump to previous year on previous arrow click if current ' +
@@ -88,7 +88,7 @@ describe('<DateField />', () => {
     expect(value).toBeDefined();
     expect(value.getFullYear()).toBe(1994);
     expect(value.getMonth()).toBe(11);
-    expect(value.getDate()).toBe(17);
+    expect(value.getDate()).toBe(1);
   });
 
   it('should display next month on next arrow click', () => {
@@ -103,7 +103,7 @@ describe('<DateField />', () => {
     expect(value).toBeDefined();
     expect(value.getFullYear()).toBe(1995);
     expect(value.getMonth()).toBe(11);
-    expect(value.getDate()).toBe(17);
+    expect(value.getDate()).toBe(1);
   });
 
   it('should jump to next year on next arrow click if current ' +
@@ -119,7 +119,7 @@ describe('<DateField />', () => {
     expect(value).toBeDefined();
     expect(value.getFullYear()).toBe(1996);
     expect(value.getMonth()).toBe(0);
-    expect(value.getDate()).toBe(17);
+    expect(value.getDate()).toBe(1);
   });
 
   it('should show a native date field when using native prop', () => {


### PR DESCRIPTION
Because of setting day of the next month to the actual day of the month, some month's jumps occurred in the date picker.

In fact, if actual date is 31/03/2021, clicking `next month` will make a new date which is '31/04/2021', but April is a 30 days month, so 31/04/2021 equal to 01/05/2021, so calendar displays may month. 

The same problem occurred with `previous month` button but was less visible, the first click was "not working" because:

31/03/2021 -> click on `previous month` -> 31/02/2021 (which doesn't exist)-> 02/03/2021 which is march month too -> click on `previous month` again -> 02/02/2021-> the February month is displayed.