### PR TITLE
🐛fix:add keyboard handling for toggle field

### DIFF
--- a/packages/junipero/lib/ToggleField/index.js
+++ b/packages/junipero/lib/ToggleField/index.js
@@ -49,6 +49,7 @@ const ToggleField = forwardRef(({
       state.checked = !state.checked;
       dispatch({ checked: state.checked });
       e.preventDefault?.();
+      onChange({ value, checked: state.checked });
 
       return false;
     }


### PR DESCRIPTION
When using keyboard, the inner checked state was updated but the onChange event was not called.

https://user-images.githubusercontent.com/10706836/115593778-3a03e680-a2d5-11eb-9e1f-65e00f89f0fc.mov

