### PR TITLE
🐛fix(toggle): add keyboard handling for toggle field

### DIFF
--- a/packages/junipero/lib/ToggleField/index.js
+++ b/packages/junipero/lib/ToggleField/index.js
@@ -49,6 +49,7 @@ const ToggleField = forwardRef(({
       state.checked = !state.checked;
       dispatch({ checked: state.checked });
       e.preventDefault?.();
+      onChange({ value, checked: state.checked });
 
       return false;
     }


### PR DESCRIPTION
When using keyboard, the inner checked state was updated but the onChange event was not called.

https://user-images.githubusercontent.com/10706836/115594700-55bbbc80-a2d6-11eb-86ca-cfdcdd25a112.mov

