### PR TITLE
🐛 fix(tags-field): fix missing valid state on change event

### DIFF
--- a/packages/junipero/lib/TagsField/index.js
+++ b/packages/junipero/lib/TagsField/index.js
@@ -247,16 +247,22 @@ const TagsField = forwardRef(({
       !onlyAllowOneOccurence ||
       !state.value.find(i => parseValue(i) === parseValue(o)));
 
+    state.valid = validate(state.value) &&
+      state.value.every(t => validateTag(t));
+
     dispatch({
       value: state.value,
-      valid: validate(state.value) && state.value.every(t => validateTag(t)),
+      valid: state.valid,
       availableOptions: state.availableOptions,
       inputValue: '',
       inputDirty: false,
       inputValid: true,
       dirty: true,
     });
-    onChange({ value: state.value.map(i => parseValue(i)) });
+    onChange({
+      value: state.value.map(i => parseValue(i)),
+      valid: state.valid,
+    });
 
     if (state.searchResults) {
       dispatch({ searchResults: null, searching: false });
@@ -277,13 +283,19 @@ const TagsField = forwardRef(({
       !onlyAllowOneOccurence ||
       !state.value.find(i => parseValue(i) === parseValue(o)));
 
+    state.valid = validate(state.value) &&
+      state.value.every(t => validateTag(t));
+
     dispatch({
       value: state.value,
-      valid: validate(state.value) && state.value.every(t => validateTag(t)),
+      valid: state.valid,
       availableOptions: state.availableOptions,
       dirty: true,
     });
-    onChange({ value: state.value.map(i => parseValue(i)) });
+    onChange({
+      value: state.value.map(i => parseValue(i)),
+      valid: state.valid,
+    });
   };
 
   const focus = index => {

--- a/packages/junipero/lib/TagsField/index.js
+++ b/packages/junipero/lib/TagsField/index.js
@@ -52,7 +52,7 @@ const TagsField = forwardRef(({
   const menuRef = useRef();
   const [state, dispatch] = useReducer(mockState, {
     value: [...(value || [])],
-    valid: validate(value || []) && (value || []).every(t => validateTag(t)),
+    valid: validate(value || []) && (value || []).every(validateTag),
     availableOptions: options,
     inputValue: '',
     inputValid: true,
@@ -93,7 +93,7 @@ const TagsField = forwardRef(({
 
     dispatch({
       value: state.value,
-      valid: validate(state.value) && state.value.every(t => validateTag(t)),
+      valid: validate(state.value) && state.value.every(validateTag),
     });
   }, [value]);
 
@@ -247,8 +247,7 @@ const TagsField = forwardRef(({
       !onlyAllowOneOccurence ||
       !state.value.find(i => parseValue(i) === parseValue(o)));
 
-    state.valid = validate(state.value) &&
-      state.value.every(t => validateTag(t));
+    state.valid = validate(state.value) && state.value.every(validateTag);
 
     dispatch({
       value: state.value,
@@ -260,7 +259,7 @@ const TagsField = forwardRef(({
       dirty: true,
     });
     onChange({
-      value: state.value.map(i => parseValue(i)),
+      value: state.value.map(parseValue),
       valid: state.valid,
     });
 
@@ -283,8 +282,7 @@ const TagsField = forwardRef(({
       !onlyAllowOneOccurence ||
       !state.value.find(i => parseValue(i) === parseValue(o)));
 
-    state.valid = validate(state.value) &&
-      state.value.every(t => validateTag(t));
+    state.valid = validate(state.value) && state.value.every(validateTag);
 
     dispatch({
       value: state.value,
@@ -293,7 +291,7 @@ const TagsField = forwardRef(({
       dirty: true,
     });
     onChange({
-      value: state.value.map(i => parseValue(i)),
+      value: state.value.map(parseValue),
       valid: state.valid,
     });
   };
@@ -318,7 +316,7 @@ const TagsField = forwardRef(({
     dispatch({
       value: state.value,
       dirty: false,
-      valid: validate(state.value) && state.value.every(t => validateTag(t)),
+      valid: validate(state.value) && state.value.every(validateTag),
       inputValue: '',
       inputDirty: false,
       inputValid: true,

--- a/packages/junipero/lib/TagsField/index.test.js
+++ b/packages/junipero/lib/TagsField/index.test.js
@@ -167,8 +167,9 @@ describe('<TagsField />', () => {
   it('should remove a previously added tag when hitting backspace and ' +
     'input is empty', () => {
     const ref = createRef();
+    const onChange = jest.fn();
     const { container, unmount } = render(
-      <TagsField ref={ref} value={['One', 'Two']} />
+      <TagsField ref={ref} value={['One', 'Two']} onChange={onChange} />
     );
     expect(ref.current.internalValue.length).toBe(2);
     fireEvent.keyDown(container.querySelector('input'), { key: 'Backspace' });
@@ -176,6 +177,35 @@ describe('<TagsField />', () => {
     fireEvent
       .keyDown(container.querySelector('.tag:focus'), { key: 'Backspace' });
     expect(ref.current.internalValue.length).toBe(1);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      valid: true,
+      value: ['One'],
+    }));
+    unmount();
+  });
+
+  it('should left tagsfield invalid when removing the last tag and field ' +
+    'isnt required', () => {
+    const ref = createRef();
+    const onChange = jest.fn();
+    const { container, unmount } = render(
+      <TagsField
+        ref={ref}
+        value={['One']}
+        onChange={onChange}
+        required={true}
+      />
+    );
+    expect(ref.current.internalValue.length).toBe(1);
+    fireEvent.keyDown(container.querySelector('input'), { key: 'Backspace' });
+    expect(container.querySelector('.tag')).toBe(document.activeElement);
+    fireEvent
+      .keyDown(container.querySelector('.tag:focus'), { key: 'Backspace' });
+    expect(ref.current.internalValue.length).toBe(0);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      valid: false,
+      value: [],
+    }));
     unmount();
   });
 
@@ -426,11 +456,13 @@ describe('<TagsField />', () => {
     'dropdown', async () => {
     const ref = createRef();
     jest.useFakeTimers();
+    const onChange = jest.fn();
     const { container, unmount } = render(
       <TagsField
         ref={ref}
         value={[]}
         search={autoComplete}
+        onChange={onChange}
       />
     );
     await act(async () => { container.querySelector('input').focus(); });
@@ -443,6 +475,12 @@ describe('<TagsField />', () => {
     fireEvent.click(container.querySelector('.junipero.dropdown-item a'));
     expect(ref.current.internalValue.length).toBe(1);
     expect(ref.current.internalValue.pop()).toBe('Freeman');
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        valid: true,
+        value: ['Freeman'],
+      }),
+    );
     unmount();
     jest.useRealTimers();
   });


### PR DESCRIPTION
Valid state was missing in tagsfield's onChange event.