### PR TITLE
🐛 fix(junipero): fix missing radiofield valid state

### DIFF
--- a/packages/junipero/lib/RadioField/index.js
+++ b/packages/junipero/lib/RadioField/index.js
@@ -30,6 +30,7 @@ const RadioField = forwardRef(({
     focused: null,
     dirty: false,
     value,
+    valid: false,
   });
 
   useEffect(() => {
@@ -52,6 +53,7 @@ const RadioField = forwardRef(({
     dirty: state.dirty,
     internalValue: state.value,
     isJunipero: true,
+    valid: state.valid,
   }));
 
   const onKeyDown_ = (option, e) => {

--- a/packages/junipero/lib/RadioField/index.js
+++ b/packages/junipero/lib/RadioField/index.js
@@ -40,6 +40,7 @@ const RadioField = forwardRef(({
     ) {
       dispatch({
         value: options?.find(o => parseValue(o) === parseValue(value)),
+        valid: true,
       });
     }
   }, [value, options]);
@@ -70,8 +71,8 @@ const RadioField = forwardRef(({
       return;
     }
 
-    dispatch({ value: option, dirty: true });
-    onChange({ value: parseValue(option) });
+    dispatch({ value: option, valid: true, dirty: true });
+    onChange({ value: parseValue(option), valid: true });
   };
 
   const onFocus_ = (option, index, e) => {

--- a/packages/junipero/lib/RadioField/index.test.js
+++ b/packages/junipero/lib/RadioField/index.test.js
@@ -49,6 +49,7 @@ describe('<RadioField />', () => {
     );
     expect(ref.current.innerRefs.current.length).toBe(3);
     expect(ref.current.inputRefs.current.length).toBe(3);
+    expect(ref.current.valid).toBe(false);
     expect(container.querySelectorAll('input')[0])
       .toBe(ref.current.inputRefs.current[0]);
     unmount();

--- a/packages/junipero/lib/RadioField/index.test.js
+++ b/packages/junipero/lib/RadioField/index.test.js
@@ -65,7 +65,10 @@ describe('<RadioField />', () => {
     );
     fireEvent.click(container.querySelectorAll('input')[1]);
     expect(onChange)
-      .toHaveBeenLastCalledWith(expect.objectContaining({ value: 'Pear' }));
+      .toHaveBeenLastCalledWith(expect.objectContaining({
+        value: 'Pear',
+        valid: true,
+      }));
     unmount();
   });
 


### PR DESCRIPTION
RadioFields valid state was missing, even if field is already valid.