### PR TITLE
🐛fix(checkbox): fire onChange event when toggle checkbox using keyboard

### DIFF
--- a/packages/junipero/lib/CheckboxField/index.js
+++ b/packages/junipero/lib/CheckboxField/index.js
@@ -55,6 +55,7 @@ const CheckboxField = forwardRef(({
       state.checked = !state.checked;
       dispatch({ checked: state.checked });
       e.preventDefault?.();
+      onChange({ value, checked: state.checked });
 
       return false;
     }

--- a/packages/junipero/lib/CheckboxField/index.test.js
+++ b/packages/junipero/lib/CheckboxField/index.test.js
@@ -107,4 +107,27 @@ describe('<CheckboxField />', () => {
 
     unmount();
   });
+
+  it('should call onchange event on enter or space hit ' +
+    'when focused', async () => {
+    const onChangeMock = jest.fn();
+    const { container, unmount } = render(
+      <CheckboxField onChange={onChangeMock} />
+    );
+
+    await act(async () => {
+      container.querySelector('label').focus();
+    });
+
+    expect(container.querySelectorAll('.junipero.checkbox.focused').length)
+      .toBe(1);
+
+    fireEvent.keyPress(globalThis, { key: 'Enter' });
+    expect(onChangeMock).toHaveBeenCalled();
+
+    fireEvent.keyPress(globalThis, { key: ' ' });
+    expect(onChangeMock).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
 });


### PR DESCRIPTION
For the moment, if we toggle checkbox using keyboard (space or enter hit), the `onchange` event is never triggered. This PR repairs this behavior