### PR TITLE
🐛fix(date-field): fix month jumping because of out of range day in month

### DIFF
--- a/packages/core/lib/dates/index.js
+++ b/packages/core/lib/dates/index.js
@@ -14,34 +14,29 @@ export const endOfMonth = date => {
 
 export const addMonths = (date, amount) => {
   const d = new Date(date);
-  const years = Math.floor(amount / 12);
-  const remaining = amount % 12;
+  const nextMonthDays = new Date(
+    d.getFullYear(),
+    d.getMonth() + amount + 1,
+    0
+  ).getDate();
 
-  d.setFullYear(
-    d.getFullYear() + years +
-    (d.getMonth() === 11 && remaining > 0 ? 1 : 0)
+  return new Date(
+    d.getFullYear(), d.getMonth() + amount, Math.min(nextMonthDays, d.getDate())
   );
-
-  d.setMonth(d.getMonth() === 11 ? remaining : d.getMonth() + remaining);
-
-  return d;
 };
 
 export const subMonths = (date, amount) => {
   const d = new Date(date);
-  const years = Math.floor(amount / 12);
-  const remaining = amount % 12;
 
-  d.setFullYear(
-    d.getFullYear() - years -
-    (d.getMonth() === 0 && remaining > 0 ? 1 : 0)
+  const nextMonthDays = new Date(
+    d.getFullYear(),
+    d.getMonth() - amount + 1,
+    0
+  ).getDate();
+
+  return new Date(
+    d.getFullYear(), d.getMonth() - amount, Math.min(nextMonthDays, d.getDate())
   );
-
-  d.setMonth((d.getMonth() === 0 ? 11 : d.getMonth()) - remaining);
-
-  return d;
 };
 
-export const getDaysInMonth = date => {
-  return endOfMonth(date).getDate();
-};
+export const getDaysInMonth = date => endOfMonth(date).getDate();

--- a/packages/core/lib/dates/index.test.js
+++ b/packages/core/lib/dates/index.test.js
@@ -17,6 +17,12 @@ describe('dates', () => {
       expect(addMonths(new Date(2020, 10, 1), 29).getFullYear()).toBe(2023);
       expect(addMonths(new Date(2020, 10, 1), 29).getMonth()).toBe(3);
     });
+
+    it('should change date if next month has ' +
+    'less days than current', () => {
+      expect(addMonths(new Date(2022, 0, 31), 1).getDate()).toBe(28);
+      expect(addMonths(new Date(2022, 0, 31), 1).getMonth()).toBe(1);
+    });
   });
 
   describe('subMonths(date, amount)', () => {
@@ -31,6 +37,12 @@ describe('dates', () => {
     it('should sub one or several years if months go over 12', () => {
       expect(subMonths(new Date(2020, 10, 1), 29).getFullYear()).toBe(2018);
       expect(subMonths(new Date(2020, 10, 1), 29).getMonth()).toBe(5);
+    });
+
+    it('should change date if next month has ' +
+    'less days than current', () => {
+      expect(subMonths(new Date(2022, 2, 31), 1).getDate()).toBe(28);
+      expect(subMonths(new Date(2022, 2, 31), 1).getMonth()).toBe(1);
     });
   });
 });

--- a/packages/react/lib/DateField/index.js
+++ b/packages/react/lib/DateField/index.js
@@ -244,6 +244,16 @@ const DateField = forwardRef(({
       state.displayed.setFullYear(state.displayed.getFullYear() - 1);
     }
 
+    const maxDaysPreviousMonth = getDaysInMonth(
+      new Date(
+        state.displayed.getFullYear(),
+        state.displayed.getMonth() === 0 ? 11 : state.displayed.getMonth() - 1,
+      )
+    );
+    state.displayed.setDate(
+      Math.min(maxDaysPreviousMonth, state.displayed.getDate())
+    );
+
     state.displayed.setMonth(
       state.displayed.getMonth() === 0 ? 11 : state.displayed.getMonth() - 1
     );
@@ -257,6 +267,16 @@ const DateField = forwardRef(({
     if (state.displayed.getMonth() === 11) {
       state.displayed.setFullYear(state.displayed.getFullYear() + 1);
     }
+
+    const maxDaysPreviousMonth = getDaysInMonth(
+      new Date(
+        state.displayed.getFullYear(),
+        state.displayed.getMonth() === 11 ? 0 : state.displayed.getMonth() + 1,
+      )
+    );
+    state.displayed.setDate(
+      Math.min(maxDaysPreviousMonth, state.displayed.getDate())
+    );
 
     state.displayed.setMonth(
       state.displayed.getMonth() === 11 ? 0 : state.displayed.getMonth() + 1

--- a/packages/react/lib/DateField/index.test.js
+++ b/packages/react/lib/DateField/index.test.js
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import DateField from './';
 
@@ -61,6 +62,97 @@ describe('<DateField />', () => {
     fireEvent.click(getByText('15'));
     expect(container).toMatchSnapshot();
 
+    unmount();
+  });
+
+  it('should switch to next month when right arrow is clicked', async () => {
+    const user = userEvent.setup();
+    const currentDay = new Date(2019, 0, 15);
+    const { container, getByText, unmount } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    getByText('January');
+    const nextMonthButton = container.querySelector('.arrow-right');
+    user.click(nextMonthButton);
+    await waitFor(() => expect(getByText('February')));
+
+    unmount();
+  });
+
+  it('should switch to previous month when left arrow is clicked', async () => {
+    const user = userEvent.setup();
+    const currentDay = new Date(2019, 11, 15);
+    const { container, getByText, unmount } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    getByText('December');
+    const nextMonthButton = container.querySelector('.arrow-left');
+    user.click(nextMonthButton);
+    await waitFor(() => expect(getByText('November')));
+
+    unmount();
+  });
+
+  it('should switch to next month when right arrow is clicked ' +
+  'even if the 31th day is selected', async () => {
+    const user = userEvent.setup();
+    const currentDay = new Date(2019, 0, 31);
+    const { container, getByText, unmount } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    getByText('January');
+    const nextMonthButton = container.querySelector('.arrow-right');
+    user.click(nextMonthButton);
+    await waitFor(() => expect(getByText('February')));
+
+    unmount();
+  });
+
+  it('should switch to previous month when left arrow is clicked ' +
+  'even if the 31th day is selected', async () => {
+    const user = userEvent.setup();
+    const currentDay = new Date(2019, 11, 31);
+    const { container, getByText, unmount } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    getByText('December');
+    const nextMonthButton = container.querySelector('.arrow-left');
+    user.click(nextMonthButton);
+    await waitFor(() => expect(getByText('November')));
+
+    unmount();
+  });
+
+  it('should correctly display current month dates', async () => {
+    const currentDay = new Date(2019, 0, 15);
+    const { getAllByText, unmount } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    await waitFor(() => expect(getAllByText('31').length).toEqual(2));
+    unmount();
+  });
+
+  it('should correctly display current month dates', async () => {
+    const currentDay = new Date(2019, 0, 15);
+    const { debug, unmount, container } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    expect(
+      container.querySelectorAll('.day:not(.inactive)').length
+    ).toEqual(31);
+    debug();
+    unmount();
+  });
+
+  it('should correctly display current month dates ' +
+  'even if the 31th day is selected', async () => {
+    const currentDay = new Date(2019, 0, 31);
+    const { unmount, container } = render(
+      <DateField autoFocus={true} value={currentDay} />
+    );
+    expect(
+      container.querySelectorAll('.day:not(.inactive)').length
+    ).toEqual(31);
     unmount();
   });
 });

--- a/packages/react/lib/DateField/index.test.js.snap
+++ b/packages/react/lib/DateField/index.test.js.snap
@@ -121,7 +121,7 @@ exports[`<DateField /> should allow to navigate between months: next month 1`] =
               class="day junipero info inactive"
               href="#"
             >
-              30
+              31
             </a>
             <a
               class="day junipero info active"


### PR DESCRIPTION
As we did not verify date in month before switching month on date field javascript was attempting to create a date like `new Date(2022, 10, 31)`, i.e 31st of november, 2022, a date which do not exist... So javascript fallback by creating the valid date 1st of December 2022, and our field was displaying december instead of november. The same problem was present on `addMonths` and `subMonths` core methods