### PR TITLE
🐛 fix(theme): prevent radiofield checkbox shrink

### DIFF
--- a/packages/theme/lib/RadioField.sass
+++ b/packages/theme/lib/RadioField.sass
@@ -14,6 +14,7 @@
       border-radius: 50%
       margin-right: 10px
       margin-top: 4px
+      flex-shrink: 0
 
     &.checked
       .inner


### PR DESCRIPTION
Before 
![image](https://user-images.githubusercontent.com/16649348/204812522-68e515dd-3ec1-478f-9d7f-b4d96945e770.png)
After 
![image](https://user-images.githubusercontent.com/16649348/204812556-3556e7f1-b0fd-40b8-8edd-859491de4e19.png)
