### PR TITLE
✨ feat: add new Transition component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,6 +17,7 @@ module.exports = {
     config.resolve.alias = {
       'react-native': 'react-native-web',
       '@junipero/core': path.resolve('./packages/core/lib'),
+      '@junipero/react': path.resolve('./packages/react/lib'),
       '@junipero/hooks': path.resolve('./packages/hooks/lib'),
       '@junipero/transitions': path.resolve('./packages/transitions/lib'),
     };

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "react-native-web": "0.18.10",
     "react-popper": "2.3.0",
     "react-test-renderer": "18.2.0",
-    "react-transition-group": "4.4.5",
     "rollup": "3.4.0",
     "rollup-plugin-dts": "5.0.0",
     "rollup-plugin-peer-deps-external": "2.2.4",

--- a/packages/hooks/lib/index.d.ts
+++ b/packages/hooks/lib/index.d.ts
@@ -1,0 +1,29 @@
+export declare function useEventListener(
+  name: string,
+  handler: Function,
+  options: { target?: any, enabled?: Boolean }): void;
+
+export declare function useInterval(
+  cb: Function,
+  time: Number,
+  changes?: Array<any>,
+  options: { enabled?: boolean, layoutEffect?: boolean }
+  ): void;
+
+export declare function useTimeout(
+  cb: Function,
+  time: Number,
+  changes?: Array<any>,
+  options: { enabled?: boolean, layoutEffect?: boolean }
+): void;
+
+export declare function UseEffectAfterMount(
+  cb: Function,
+  changes: Array<any>
+): void;
+
+export declare function useLayoutEffectAfterMount(
+  cb: Function,
+  changes: Array<any>,
+  options: { layoutEffect?: Boolean }
+): void;

--- a/packages/hooks/lib/index.d.ts
+++ b/packages/hooks/lib/index.d.ts
@@ -6,18 +6,18 @@ export declare function useEventListener(
 export declare function useInterval(
   cb: Function,
   time: Number,
+  options: { enabled?: boolean, layoutEffect?: boolean },
   changes?: Array<any>,
-  options: { enabled?: boolean, layoutEffect?: boolean }
   ): void;
 
 export declare function useTimeout(
   cb: Function,
   time: Number,
+  options: { enabled?: boolean, layoutEffect?: boolean },
   changes?: Array<any>,
-  options: { enabled?: boolean, layoutEffect?: boolean }
 ): void;
 
-export declare function UseEffectAfterMount(
+export declare function useEffectAfterMount(
   cb: Function,
   changes: Array<any>
 ): void;
@@ -25,5 +25,4 @@ export declare function UseEffectAfterMount(
 export declare function useLayoutEffectAfterMount(
   cb: Function,
   changes: Array<any>,
-  options: { layoutEffect?: Boolean }
 ): void;

--- a/packages/hooks/lib/index.js
+++ b/packages/hooks/lib/index.js
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useLayoutEffect } from 'react';
 
 export const useEventListener = (
   name,
@@ -28,11 +28,11 @@ export const useEventListener = (
 };
 
 export const useInterval = (
-  cb, time, changes = [], { enabled = true } = {}
+  cb, time, changes = [], { enabled = true, layoutEffect = false } = {}
 ) => {
   const returnedCallbackRef = useRef();
 
-  useEffect(() => {
+  (layoutEffect ? useLayoutEffect : useEffect)(() => {
     if (!enabled) {
       return;
     }
@@ -49,11 +49,11 @@ export const useInterval = (
 };
 
 export const useTimeout = (
-  cb, time, changes = [], { enabled = true } = {}
+  cb, time, changes = [], { enabled = true, layoutEffect = false } = {}
 ) => {
   const returnedCallbackRef = useRef();
 
-  useEffect(() => {
+  (layoutEffect ? useLayoutEffect : useEffect)(() => {
     if (!enabled) {
       return;
     }
@@ -68,3 +68,23 @@ export const useTimeout = (
     };
   }, changes);
 };
+
+const useAfterMount = (cb, changes = [], { layoutEffect = false } = {}) => {
+  const mounted = useRef(false);
+
+  (layoutEffect ? useLayoutEffect : useEffect)(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+
+      return;
+    }
+
+    return cb();
+  }, changes);
+};
+
+export const useEffectAfterMount = (cb, changes = []) =>
+  useAfterMount(cb, changes);
+
+export const useLayoutEffectAfterMount = (cb, changes = []) =>
+  useAfterMount(cb, changes, { layoutEffect: true });

--- a/packages/hooks/lib/index.test.js
+++ b/packages/hooks/lib/index.test.js
@@ -2,7 +2,13 @@ import { useState } from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { classNames } from '@junipero/core';
 
-import { useEventListener, useTimeout, useInterval } from './';
+import {
+  useEventListener,
+  useTimeout,
+  useInterval,
+  useEffectAfterMount,
+  useLayoutEffectAfterMount,
+} from './';
 
 /* eslint-disable react/prop-types */
 const TestComponent = ({ target, onTimeout, onInterval }) => {
@@ -62,5 +68,45 @@ describe('useTimeout(listener, time, changes)', () => {
     unmount();
     jest.clearAllTimers();
     jest.useRealTimers();
+  });
+});
+
+/* eslint-disable react/prop-types */
+const EffectsTestComponent = ({ enabled, onEffect, onLayoutEffect }) => {
+  onEffect && useEffectAfterMount(() => {
+    onEffect();
+  }, [enabled]);
+
+  onLayoutEffect && useLayoutEffectAfterMount(() => {
+    onLayoutEffect();
+  }, [enabled]);
+
+  return null;
+};
+/* eslint-enable react/prop-types */
+
+describe('useEffectAfterMount(cb, changes)', () => {
+  it('should execute task after mount', () => {
+    const onEffect = jest.fn();
+    const { unmount, rerender } = render(
+      <EffectsTestComponent enabled={false} onEffect={onEffect} />
+    );
+    rerender(<EffectsTestComponent enabled={true} onEffect={onEffect} />);
+    expect(onEffect).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});
+
+describe('useLayoutEffectAfterMount(cb, changes)', () => {
+  it('should execute task after mount', () => {
+    const onLayoutEffect = jest.fn();
+    const { unmount, rerender } = render(
+      <EffectsTestComponent enabled={false} onLayoutEffect={onLayoutEffect} />
+    );
+    rerender(
+      <EffectsTestComponent enabled={true} onLayoutEffect={onLayoutEffect} />
+    );
+    expect(onLayoutEffect).toHaveBeenCalledTimes(1);
+    unmount();
   });
 });

--- a/packages/hooks/rollup.config.mjs
+++ b/packages/hooks/rollup.config.mjs
@@ -4,6 +4,7 @@ import babel from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
+import dts from 'rollup-plugin-dts';
 
 const input = './lib/index.js';
 const output = './dist';
@@ -25,26 +26,31 @@ const defaultPlugins = [
   terser(),
 ];
 
-export default formats.map(f => ({
-  input,
-  plugins: [
-    ...defaultPlugins,
-  ],
-  external: defaultExternals,
-  output: {
-    ...(f === 'esm' ? {
-      dir: `${output}/esm`,
-      chunkFileNames: '[name].js',
-    } : {
-      file: `${output}/${name}.${f}.js`,
-    }),
-    format: f,
-    name,
-    sourcemap: true,
-    globals: defaultGlobals,
-    ...(f === 'esm' ? {
-      manualChunks: id =>
-        id.includes('node_modules') ? 'vendor' : path.parse(id).name,
-    } : {}),
-  },
-}));
+export default [
+  ...formats.map(f => ({
+    input,
+    plugins: [
+      ...defaultPlugins,
+    ],
+    external: defaultExternals,
+    output: {
+      ...(f === 'esm' ? {
+        dir: `${output}/esm`,
+        chunkFileNames: '[name].js',
+      } : {
+        file: `${output}/${name}.${f}.js`,
+      }),
+      format: f,
+      name,
+      sourcemap: true,
+      globals: defaultGlobals,
+      ...(f === 'esm' ? {
+        manualChunks: id =>
+          id.includes('node_modules') ? 'vendor' : path.parse(id).name,
+      } : {}),
+    },
+  })), {
+    input: './lib/index.d.ts',
+    output: [{ file: `dist/${name}.d.ts`, format: 'es' }],
+    plugins: [dts()],
+  }];

--- a/packages/react/lib/Transition/index.d.ts
+++ b/packages/react/lib/Transition/index.d.ts
@@ -2,9 +2,9 @@ import React from 'react';
 
 declare interface TransitionProps extends React.ComponentPropsWithRef<any> {
   children?: string | React.ReactNode | Function;
-  in?: Boolean;
+  in: Boolean;
   name?: String;
-  timeout?: Number;
+  timeout?: Number | { enter: Number, exit: Number };
   mounterOnEnter?: Boolean;
   unmountOnExit?: Boolean;
 }

--- a/packages/react/lib/Transition/index.d.ts
+++ b/packages/react/lib/Transition/index.d.ts
@@ -1,0 +1,14 @@
+import React from 'react';
+
+declare interface TransitionProps extends React.ComponentPropsWithRef<any> {
+  children?: string | React.ReactNode | Function;
+  in?: Boolean;
+  name?: String;
+  timeout?: Number;
+  mounterOnEnter?: Boolean;
+  unmountOnExit?: Boolean;
+}
+
+declare function Transition(props: TransitionProps): JSX.Element;
+
+export default Transition;

--- a/packages/react/lib/Transition/index.js
+++ b/packages/react/lib/Transition/index.js
@@ -1,0 +1,80 @@
+import { Children, useState, useCallback, cloneElement } from 'react';
+import { useTimeout, useLayoutEffectAfterMount } from '@junipero/hooks';
+import { classNames } from '@junipero/core';
+import PropTypes from 'prop-types';
+
+const UNMOUNTED = 'unmounted';
+const ENTER = 'enter';
+const EXIT = 'exit';
+const IDLE = 'idle';
+const STARTING = 'starting';
+const ACTIVE = 'active';
+const DONE = 'done';
+
+const Transition = ({
+  children,
+  in: inProp,
+  name = 'transition',
+  timeout = 100,
+  mountOnEnter = true,
+  unmountOnExit = false,
+  ...rest
+}) => {
+  const [status, setStatus] = useState(inProp ? ENTER : UNMOUNTED);
+  const [step, setStep] = useState(inProp ? STARTING : IDLE);
+
+  useLayoutEffectAfterMount(() => {
+    setStatus(inProp ? ENTER : EXIT);
+    setStep(STARTING);
+  }, [inProp]);
+
+  useTimeout(() => {
+    setStep(ACTIVE);
+  }, 0, [step], { enabled: step === STARTING });
+
+  useTimeout(() => {
+    if (step !== IDLE) {
+      setStep(DONE);
+    }
+  }, timeout?.enter ?? timeout, [status, step], {
+    enabled: status === ENTER,
+  });
+
+  useTimeout(() => {
+    if (step !== IDLE) {
+      setStatus(UNMOUNTED);
+      setStep(DONE);
+    }
+  }, timeout?.exit ?? timeout, [status, step], {
+    enabled: status === EXIT,
+  });
+
+  const getClassName = useCallback(() => (
+    name + '-' + status + (![IDLE, STARTING].includes(step) ? '-' + step : '')
+  ), [status, step]);
+
+  const child = Children.only(children);
+
+  return status !== UNMOUNTED && (!unmountOnExit || mountOnEnter)
+    ? cloneElement(child, {
+      className: classNames(child.props.className, getClassName()),
+      ...rest,
+    }) : null;
+};
+
+Transition.displayName = 'Transition';
+Transition.propTypes = {
+  in: PropTypes.bool,
+  name: PropTypes.string,
+  timeout: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
+  ]),
+  mountOnEnter: PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
+};
+
+export default Transition;

--- a/packages/react/lib/Transition/index.stories.js
+++ b/packages/react/lib/Transition/index.stories.js
@@ -1,0 +1,42 @@
+import { useReducer } from 'react';
+import { mockState } from '@junipero/core';
+
+import Button from '../Button';
+import Label from '../Label';
+import TextField from '../TextField';
+import Transition from '.';
+
+export default { title: 'react/Transition' };
+
+export const basic = () => {
+  const [state, dispatch] = useReducer(mockState, {
+    enabled: false,
+    timeout: 100,
+  });
+
+  return (
+    <>
+      <div>
+        <Label>Timeout (in ms)</Label>
+        <TextField
+          value={state.timeout}
+          onChange={e => dispatch({ timeout: Number(e.value) })}
+        />
+      </div>
+      <p>
+        <Button
+          onClick={() => dispatch({ enabled: !state.enabled })}
+        >
+          Toggle animation
+        </Button>
+      </p>
+      <Transition
+        in={state.enabled}
+        timeout={state.timeout}
+        name="jp-slide-in-down-menu"
+      >
+        <div>Text</div>
+      </Transition>
+    </>
+  );
+};

--- a/packages/react/lib/Transition/index.test.js
+++ b/packages/react/lib/Transition/index.test.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+import Transition from '.';
+
+describe('<Transition />', () => {
+  it('should render correctly', () => {
+    jest.useFakeTimers();
+
+    const Comp = () => {
+      const [enabled, setEnabled] = useState(false);
+
+      return (
+        <>
+          <button onClick={() => setEnabled(e => !e)}>Toggle</button>
+          <Transition in={enabled} timeout={100}>
+            <div>Animated text</div>
+          </Transition>
+        </>
+      );
+    };
+
+    const { container, unmount } = render(<Comp />);
+    expect(container).toMatchSnapshot();
+    fireEvent.click(container.querySelector('button'));
+    jest.advanceTimersByTime(100);
+    expect(container).toMatchSnapshot();
+    unmount();
+  });
+});

--- a/packages/react/lib/Transition/index.test.js.snap
+++ b/packages/react/lib/Transition/index.test.js.snap
@@ -14,7 +14,7 @@ exports[`<Transition /> should render correctly 2`] = `
     Toggle
   </button>
   <div
-    class="undefined-enter"
+    class="transition-enter"
   >
     Animated text
   </div>

--- a/packages/react/lib/Transition/index.test.js.snap
+++ b/packages/react/lib/Transition/index.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Transition /> should render correctly 1`] = `
+<div>
+  <button>
+    Toggle
+  </button>
+</div>
+`;
+
+exports[`<Transition /> should render correctly 2`] = `
+<div>
+  <button>
+    Toggle
+  </button>
+  <div
+    class="undefined-enter"
+  >
+    Animated text
+  </div>
+</div>
+`;

--- a/packages/react/lib/index.d.ts
+++ b/packages/react/lib/index.d.ts
@@ -34,6 +34,7 @@ import Tab, { TabRef } from './Tab';
 import Tabs, { TabsRef } from './Tabs';
 import Tag, { TagRef } from './Tag';
 import TextField, { TextFieldRef } from './TextField';
+import Transition from './Transition';
 import Toggle, { ToggleRef } from './Toggle';
 import Tooltip, { TooltipRef } from './Tooltip';
 import TouchableZone from './TouchableZone';
@@ -73,6 +74,7 @@ export {
   Tabs,
   Tag,
   TextField,
+  Transition,
   Toggle,
   Tooltip,
   TouchableZone,

--- a/packages/react/lib/index.js
+++ b/packages/react/lib/index.js
@@ -24,6 +24,7 @@ export { default as Tag } from './Tag';
 export { default as Toggle } from './Toggle';
 export { default as Tooltip } from './Tooltip';
 export { default as TouchableZone } from './TouchableZone';
+export { default as Transition } from './Transition';
 
 // Forms
 export { default as CheckboxField } from './CheckboxField';
@@ -74,6 +75,8 @@ export {
   useEventListener,
   useInterval,
   useTimeout,
+  useEffectAfterMount,
+  useLayoutEffectAfterMount,
 } from '@junipero/hooks';
 
 export {

--- a/packages/theme/lib/transitions.sass
+++ b/packages/theme/lib/transitions.sass
@@ -82,6 +82,9 @@
     &.junipero.modal .wrapper
       background: var(--transition-background-exit)
 
+      .content
+        opacity: 0
+
     &-active
       &.junipero.modal .wrapper
         transition: background .2s ease-out

--- a/packages/theme/lib/transitions.sass
+++ b/packages/theme/lib/transitions.sass
@@ -22,14 +22,16 @@
       transition-duration: 100ms
 
 .jp-slide-in-down-menu
-  &-enter
+  &-enter, &-appear
     opacity: 0
     transform: translate3d(0, -10px, 0)
 
     &-active
       opacity: 1
       transform: translate3d(0, 0, 0)
-      transition: opacity .1s ease-out, transform .1s ease-out
+      transition-property: opacity, transform
+      transition-timing-function: ease-out
+      transition-duration: 100ms
 
   &-exit
     opacity: 1
@@ -38,7 +40,9 @@
     &-active
       opacity: 0
       transform: translate3d(0, -10px, 0)
-      transition: opacity .1s ease-out, transform .1s ease-out
+      transition-property: opacity, transform
+      transition-timing-function: ease-out
+      transition-duration: 100ms
 
 .jp-slide-in-left-modal
   &-enter

--- a/packages/transitions/lib/index.js
+++ b/packages/transitions/lib/index.js
@@ -1,17 +1,16 @@
-import { CSSTransition } from 'react-transition-group';
+import { Transition } from '@junipero/react';
 
 export const animateMenu = (
   name,
   { time = 100, ...opts } = {}
 ) =>
   (menu, { opened } = {}) => (
-    <CSSTransition
+    <Transition
       in={opened}
-      appear={true}
       mountOnEnter={true}
       unmountOnExit={true}
       timeout={time}
-      classNames={name}
+      name={name}
       children={menu}
       { ...opts }
     />
@@ -25,12 +24,12 @@ export const animateModal = (
   { time = 300, ...opts } = {}
 ) =>
   (modal, { opened } = {}) => (
-    <CSSTransition
+    <Transition
       in={opened}
       mountOnEnter={true}
       unmountOnExit={true}
       timeout={time}
-      classNames={name}
+      name={name}
       children={modal}
       { ...opts }
     />
@@ -39,4 +38,4 @@ export const animateModal = (
 export const slideInUpModal = animateModal('jp-slide-in-up-modal');
 export const slideInLeftModal = animateModal('jp-slide-in-left-modal');
 export const appearBounceModal = animateModal('jp-appear-bounce-modal',
-  { time: 200, appear: true });
+  { time: 200 });

--- a/packages/transitions/package.json
+++ b/packages/transitions/package.json
@@ -21,8 +21,8 @@
     "yarn": ">= 1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-transition-group": "^4.0.0"
+    "@junipero/react": "^3.0.0-alpha.13",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@babel/runtime-corejs3": "7.20.1",

--- a/packages/transitions/rollup.config.mjs
+++ b/packages/transitions/rollup.config.mjs
@@ -4,16 +4,16 @@ import babel from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
+import alias from '@rollup/plugin-alias';
 
 const input = './lib/index.js';
 const output = './dist';
 const name = 'junipero-transitions';
 const formats = ['umd', 'cjs', 'esm'];
 
-const defaultExternals = ['react', 'react-transition-group'];
+const defaultExternals = ['react'];
 const defaultGlobals = {
   react: 'React',
-  'react-transition-group': 'ReactTransitionGroup',
 };
 
 const defaultPlugins = [
@@ -21,6 +21,13 @@ const defaultPlugins = [
   babel({
     exclude: /node_modules/,
     babelHelpers: 'runtime',
+  }),
+  alias({
+    entries: {
+      '@junipero/react': path.resolve('../react/lib'),
+      '@junipero/hooks': path.resolve('../hooks/lib'),
+      '@junipero/core': path.resolve('../core/lib'),
+    },
   }),
   resolve(),
   terser(),

--- a/packages/transitions/rollup.config.mjs
+++ b/packages/transitions/rollup.config.mjs
@@ -11,9 +11,13 @@ const output = './dist';
 const name = 'junipero-transitions';
 const formats = ['umd', 'cjs', 'esm'];
 
-const defaultExternals = ['react'];
+const defaultExternals = [
+  'react',
+  '@junipero/react',
+];
 const defaultGlobals = {
   react: 'React',
+  '@junipero/react': 'JuniperoReact',
 };
 
 const defaultPlugins = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,7 +1146,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.10"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
   integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
@@ -7302,14 +7302,6 @@ dom-converter@^0.2.0:
   integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
-
-dom-helpers@^5.0.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
 
 dom-serializer@^1.0.1:
   version "1.4.1"
@@ -13482,7 +13474,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.8.1, prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.8.1, prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -13856,16 +13848,6 @@ react-test-renderer@18.2.0:
     react-is "^18.2.0"
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
-
-react-transition-group@4.4.5:
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
-  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    dom-helpers "^5.0.1"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
 
 react@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
Crafted as a drop-in replacement for CSSTransition, with a bunch of things being left out on purpose.
CSSTransition still uses React.Component classes and does weird (probably unneeded) things with DOM elements.
Junipero's `Transition` only uses hooks & the `classNames` util.

```jsx
<Transition name="my-animation" timeout={100}>
  <div>Text</div>
</Transition>
```

This PR also adds the needed `useLayoutEffectAfterMount` (& its sibling `useEffectAfterMount`) hooks, and removes the need for `react-transition-group` inside `@junipero/transitions`.