### PR TITLE
🐛 fix(react): fix wrong selectfield's baskpace behavior

### DIFF
--- a/packages/react/lib/SelectField/index.js
+++ b/packages/react/lib/SelectField/index.js
@@ -268,6 +268,10 @@ const SelectField = forwardRef(({
 
     switch (e.key) {
       case 'Backspace':
+        if (state.search) {
+          return;
+        }
+
         if (state.selectedItem >= 0) {
           onRemoveOption(state.value[state.selectedItem]);
         } else {

--- a/packages/react/lib/SelectField/index.test.js
+++ b/packages/react/lib/SelectField/index.test.js
@@ -294,6 +294,34 @@ describe('<SelectField />', () => {
     unmount();
   });
 
+  it('should not remove field previous values while hitting ' +
+    'backspace, if search isnt empty', async () => {
+    const user = userEvent.setup();
+    const { unmount, container } = render(
+      <SelectField
+        placeholder="Name"
+        options={['Item 1', 'Item 2']}
+        value={['Item 1']}
+        multiple={true}
+      />
+    );
+
+    await user.click(container.querySelector('input'));
+
+    await user.type(container.querySelector('input'), 'Item');
+    // Cannot use .useFakeTimers() as user.type uses timers :/
+    await sleep(1);
+    expect(container).toMatchSnapshot();
+
+    // Remove 'Item' written text without removing previous values
+    await Promise.all(
+      Array.from({ length: 4 }).map(() => user.keyboard('{BackSpace}'))
+    );
+    expect(container).toMatchSnapshot();
+
+    unmount();
+  });
+
   it('should allow to use object options and display custom titles on a ' +
     'controlled field', async () => {
     const user = userEvent.setup();

--- a/packages/react/lib/SelectField/index.test.js.snap
+++ b/packages/react/lib/SelectField/index.test.js.snap
@@ -1595,6 +1595,186 @@ exports[`<SelectField /> should not allow to change value when disabled 1`] = `
 </div>
 `;
 
+exports[`<SelectField /> should not remove field previous values while hitting backspace, if search isnt empty 1`] = `
+<div>
+  <div
+    class="junipero dropdown opened select-field pristine valid searchable focused multiple"
+  >
+    <div
+      class="field dropdown-toggle opened"
+    >
+      <span
+        class="junipero tag info"
+      >
+        <span>
+          Item 1
+        </span>
+        <svg
+          class="junipero icon remove"
+          height="10"
+          viewBox="0 0 9 10"
+          width="10"
+        >
+          <path
+            d="M8 1.5L1 8.5"
+          />
+          <path
+            d="M1 1.5L8 8.5"
+          />
+        </svg>
+      </span>
+      <input
+        placeholder="Name"
+        size="10"
+        type="text"
+        value="Item"
+      />
+      <div
+        class="icons"
+      >
+        <svg
+          class="junipero icon remove"
+          height="10"
+          viewBox="0 0 9 10"
+          width="10"
+        >
+          <path
+            d="M8 1.5L1 8.5"
+          />
+          <path
+            d="M1 1.5L8 8.5"
+          />
+        </svg>
+        <svg
+          class="junipero icon arrows"
+          height="13"
+          viewBox="0 0 8 13"
+          width="8"
+        >
+          <path
+            d="M1 4.5L4 1.5L7 4.5"
+          />
+          <path
+            d="M1 8.5L4 11.5L7 8.5"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="junipero dropdown-menu select-menu"
+      style="position: fixed; top: 10px; left: 0px;"
+      tabindex="-1"
+    >
+      <ul
+        class="menu-inner"
+      >
+        <div
+          class="content"
+        >
+          <li
+            class="dropdown-item"
+          >
+            <a>
+              Item 2
+            </a>
+          </li>
+        </div>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<SelectField /> should not remove field previous values while hitting backspace, if search isnt empty 2`] = `
+<div>
+  <div
+    class="junipero dropdown opened select-field pristine valid searchable focused multiple"
+  >
+    <div
+      class="field dropdown-toggle opened"
+    >
+      <span
+        class="junipero tag info selected"
+      >
+        <span>
+          Item 1
+        </span>
+        <svg
+          class="junipero icon remove"
+          height="10"
+          viewBox="0 0 9 10"
+          width="10"
+        >
+          <path
+            d="M8 1.5L1 8.5"
+          />
+          <path
+            d="M1 1.5L8 8.5"
+          />
+        </svg>
+      </span>
+      <input
+        placeholder="Name"
+        size="10"
+        type="text"
+        value=""
+      />
+      <div
+        class="icons"
+      >
+        <svg
+          class="junipero icon remove"
+          height="10"
+          viewBox="0 0 9 10"
+          width="10"
+        >
+          <path
+            d="M8 1.5L1 8.5"
+          />
+          <path
+            d="M1 1.5L8 8.5"
+          />
+        </svg>
+        <svg
+          class="junipero icon arrows"
+          height="13"
+          viewBox="0 0 8 13"
+          width="8"
+        >
+          <path
+            d="M1 4.5L4 1.5L7 4.5"
+          />
+          <path
+            d="M1 8.5L4 11.5L7 8.5"
+          />
+        </svg>
+      </div>
+    </div>
+    <div
+      class="junipero dropdown-menu select-menu"
+      style="position: fixed; top: 10px; left: 0px;"
+      tabindex="-1"
+    >
+      <ul
+        class="menu-inner"
+      >
+        <div
+          class="content"
+        >
+          <li
+            class="dropdown-item"
+          >
+            <a>
+              Item 2
+            </a>
+          </li>
+        </div>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<SelectField /> should render 1`] = `
 <div>
   <div


### PR DESCRIPTION
At the moment, if you search something and decide to backspace to erase some characters, it removes field previous selected values instead.

https://user-images.githubusercontent.com/8899958/220140563-b2c4639d-6e6f-40ad-a35f-0cf3d9d3734b.mov

This PR fixes this unwanted behavior.
It also adds a unitary test and linked snapshots.
