### PR TITLE
🐛 fix: react server components compat

### DIFF
--- a/packages/react/lib/BreadCrumb/index.d.ts
+++ b/packages/react/lib/BreadCrumb/index.d.ts
@@ -1,6 +1,7 @@
 import { ReactNode, MutableRefObject, ComponentPropsWithRef } from 'react';
 
 export declare type BreadCrumbRef = {
+  items: Array<ReactNode | JSX.Element>;
   isJunipero: boolean;
   innerRef: MutableRefObject<any>;
 };
@@ -8,6 +9,7 @@ export declare type BreadCrumbRef = {
 declare interface BreadCrumbProps extends ComponentPropsWithRef<any> {
   children?: ReactNode | JSX.Element;
   className?: string;
+  items?: Array<ReactNode | JSX.Element>;
   maxItems?: number;
   filterItem?(children: ReactNode | JSX.Element): boolean;
   ref?: MutableRefObject<BreadCrumbRef | undefined>;

--- a/packages/react/lib/BreadCrumb/index.stories.js
+++ b/packages/react/lib/BreadCrumb/index.stories.js
@@ -48,3 +48,11 @@ export const withConditionalItems = () => {
     </>
   );
 };
+
+export const withItemsProp = () => (
+  <BreadCrumb items={['One', 'Two', 'Three']} />
+);
+
+export const withItemsPropCollapsed = () => (
+  <BreadCrumb items={['One', 'Two', 'Three']} maxItems={2} />
+);

--- a/packages/react/lib/BreadCrumb/index.test.js
+++ b/packages/react/lib/BreadCrumb/index.test.js
@@ -62,4 +62,28 @@ describe('<BreadCrumb />', () => {
 
     unmount();
   });
+
+  it('should allow to render from items prop', () => {
+    const { container, unmount } = render(
+      <BreadCrumb items={['One', 'Two', 'Three']} />
+    );
+
+    expect(container).toMatchSnapshot();
+
+    unmount();
+  });
+
+  it('should allow to render from items prop with maxItems', () => {
+    const { container, getByText, unmount } = render(
+      <BreadCrumb items={['One', 'Two', 'Three', 'Four']} maxItems={3} />
+    );
+
+    expect(container).toMatchSnapshot('Collapsed');
+
+    fireEvent.click(getByText('...'));
+
+    expect(container).toMatchSnapshot('Opened');
+
+    unmount();
+  });
 });

--- a/packages/react/lib/BreadCrumb/index.test.js.snap
+++ b/packages/react/lib/BreadCrumb/index.test.js.snap
@@ -58,6 +58,88 @@ exports[`<BreadCrumb /> should allow to conditionnaly add items inside fragments
 </div>
 `;
 
+exports[`<BreadCrumb /> should allow to render from items prop 1`] = `
+<div>
+  <div
+    class="junipero breadcrumb"
+  >
+    <span
+      class="item"
+    >
+      One
+    </span>
+    <span
+      class="item"
+    >
+      Two
+    </span>
+    <span
+      class="item"
+    >
+      Three
+    </span>
+  </div>
+</div>
+`;
+
+exports[`<BreadCrumb /> should allow to render from items prop with maxItems: Collapsed 1`] = `
+<div>
+  <div
+    class="junipero breadcrumb collapsed"
+  >
+    <span
+      class="item"
+    >
+      One
+    </span>
+    <span
+      class="item"
+    >
+      Two
+    </span>
+    <a
+      class="item"
+    >
+      ...
+    </a>
+    <span
+      class="item"
+    >
+      Four
+    </span>
+  </div>
+</div>
+`;
+
+exports[`<BreadCrumb /> should allow to render from items prop with maxItems: Opened 1`] = `
+<div>
+  <div
+    class="junipero breadcrumb opened"
+  >
+    <span
+      class="item"
+    >
+      One
+    </span>
+    <span
+      class="item"
+    >
+      Two
+    </span>
+    <span
+      class="item"
+    >
+      Three
+    </span>
+    <span
+      class="item"
+    >
+      Four
+    </span>
+  </div>
+</div>
+`;
+
 exports[`<BreadCrumb /> should render 1`] = `
 <div>
   <div

--- a/packages/react/lib/Tab/index.d.ts
+++ b/packages/react/lib/Tab/index.d.ts
@@ -5,6 +5,11 @@ import {
   MutableRefObject,
 } from 'react';
 
+export declare interface TabObject {
+  title: ReactNode | JSX.Element;
+  content: ReactNode | JSX.Element;
+}
+
 export declare type TabRef = {
   isJunipero: boolean;
   innerRef: MutableRefObject<any>;

--- a/packages/react/lib/Tabs/index.d.ts
+++ b/packages/react/lib/Tabs/index.d.ts
@@ -1,7 +1,10 @@
 import { ReactNode, ComponentPropsWithRef, MutableRefObject } from 'react';
 
+import { TabObject } from '../Tab';
+
 export declare type TabsRef = {
   activeTab: number;
+  tabs: Array<TabObject>;
   isJunipero: boolean;
   innerRef: MutableRefObject<any>;
 };
@@ -11,6 +14,7 @@ declare interface TabsProps extends ComponentPropsWithRef<any> {
   children?: ReactNode | JSX.Element;
   className?: string;
   disabled?: boolean;
+  tabs?: Array<TabObject>;
   filterTab?(child: ReactNode | JSX.Element): boolean;
   onToggle?(index: number): void;
   ref?: MutableRefObject<TabsRef | undefined>;

--- a/packages/react/lib/Tabs/index.js
+++ b/packages/react/lib/Tabs/index.js
@@ -5,6 +5,7 @@ import {
   useImperativeHandle,
   useRef,
   useState,
+  useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
 import { classNames } from '@junipero/core';
@@ -15,6 +16,7 @@ const Tabs = forwardRef(({
   className,
   children,
   active,
+  tabs,
   disabled = false,
   filterTab = child => child.type === Tab,
   onToggle,
@@ -24,9 +26,10 @@ const Tabs = forwardRef(({
   const [activeTab, setActiveTab] = useState(active);
 
   useImperativeHandle(ref, () => ({
-    innerRef,
+    tabs,
     activeTab,
     isJunipero: true,
+    innerRef,
   }));
 
   useEffect(() => {
@@ -44,7 +47,11 @@ const Tabs = forwardRef(({
     onToggle?.(index);
   };
 
-  const tabs = Children.toArray(children).filter(filterTab);
+  const availableTabs = useMemo(() => (
+    tabs
+      ? tabs.map((t, i) => <Tab key={i} title={t.title}>{ t.content }</Tab>)
+      : Children.toArray(children).filter(filterTab)
+  ), [tabs, children]);
 
   return (
     <div
@@ -57,7 +64,7 @@ const Tabs = forwardRef(({
       )}
     >
       <ul className="titles">
-        { tabs.map((tab, index) => (
+        { availableTabs.map((tab, index) => (
           <li
             key={index}
             className={classNames(
@@ -76,7 +83,7 @@ const Tabs = forwardRef(({
       </ul>
 
       <div className="content">
-        { tabs[activeTab] }
+        { availableTabs[activeTab] }
       </div>
     </div>
   );
@@ -85,6 +92,10 @@ const Tabs = forwardRef(({
 Tabs.displayName = 'Tabs';
 Tabs.propTypes = {
   active: PropTypes.number,
+  tabs: PropTypes.arrayOf(PropTypes.shape({
+    title: PropTypes.any,
+    content: PropTypes.any,
+  })),
   disabled: PropTypes.bool,
   onToggle: PropTypes.func,
   filterTab: PropTypes.func,

--- a/packages/react/lib/Tabs/index.stories.js
+++ b/packages/react/lib/Tabs/index.stories.js
@@ -11,3 +11,13 @@ export const basic = () => (
     <Tab title="Title Two">Content Two</Tab>
   </Tabs>
 );
+
+export const withTabsProp = () => (
+  <Tabs
+    tabs={[
+      { title: 'Title One', content: 'Content One' },
+      { title: 'Title Two', content: 'Content Two' },
+    ]}
+    onToggle={action('change')}
+  />
+);

--- a/packages/react/lib/Tabs/index.test.js
+++ b/packages/react/lib/Tabs/index.test.js
@@ -38,4 +38,22 @@ describe('<Tabs />', () => {
     expect(container).toMatchSnapshot();
     unmount();
   });
+
+  it('should allow to render tabs from prop', () => {
+    const onToggle = jest.fn();
+    const { container, getByText, unmount } = render(
+      <Tabs
+        tabs={[
+          { title: 'Tab 1', content: 'One' },
+          { title: 'Tab 2', content: 'Two' },
+        ]}
+        onToggle={onToggle}
+      />
+    );
+    expect(container).toMatchSnapshot('First tab');
+    fireEvent.click(getByText('Tab 2'));
+    expect(onToggle).toHaveBeenCalledWith(1);
+    expect(container).toMatchSnapshot('Second tab');
+    unmount();
+  });
 });

--- a/packages/react/lib/Tabs/index.test.js.snap
+++ b/packages/react/lib/Tabs/index.test.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Tabs /> should allow to render tabs from prop: First tab 1`] = `
+<div>
+  <div
+    class="junipero tabs"
+  >
+    <ul
+      class="titles"
+    >
+      <li
+        class="title active"
+      >
+        <a
+          href="#"
+        >
+          Tab 1
+        </a>
+      </li>
+      <li
+        class="title"
+      >
+        <a
+          href="#"
+        >
+          Tab 2
+        </a>
+      </li>
+    </ul>
+    <div
+      class="content"
+    >
+      <div
+        class="tab"
+      >
+        One
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Tabs /> should allow to render tabs from prop: Second tab 1`] = `
+<div>
+  <div
+    class="junipero tabs"
+  >
+    <ul
+      class="titles"
+    >
+      <li
+        class="title"
+      >
+        <a
+          href="#"
+        >
+          Tab 1
+        </a>
+      </li>
+      <li
+        class="title active"
+      >
+        <a
+          href="#"
+        >
+          Tab 2
+        </a>
+      </li>
+    </ul>
+    <div
+      class="content"
+    >
+      <div
+        class="tab"
+      >
+        Two
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Tabs /> should fire onToggle event when changing tab 1`] = `
 <div>
   <div


### PR DESCRIPTION
As junipero uses `createContext` and heavily relies on state management, it is therefore a client library and should be used like it. On frameworks like Next that implement the new React Server Components, we have to make a client-side wrapper that re-exports the entier junipero exports:

```js
'use client';

export * from '@junipero/react';
```

For some components, we also rely on `Children` and `.filter` to only deal with the children we want.
As all components exported from a client component are transformed into `React.lazy` components, we lose the ability to filter children on their type.

This PR adds props to these components to be able to render precise content without relying on filtering children.