### PR TITLE
✨ feat(theme): add icons

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,8 +3,7 @@ const autoprefixer = require('autoprefixer');
 
 module.exports = {
   stories: [
-    '../packages/*/lib/*/*.stories.js',
-    '../packages/*/lib/*.stories.js',
+    '../packages/*/lib/**/*.stories.js',
   ],
   addons: [
     '@storybook/addon-storysource',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ const autoprefixer = require('autoprefixer');
 module.exports = {
   stories: [
     '../packages/*/lib/*/*.stories.js',
+    '../packages/*/lib/*.stories.js',
   ],
   addons: [
     '@storybook/addon-storysource',

--- a/packages/theme/lib/dark.sass
+++ b/packages/theme/lib/dark.sass
@@ -1,6 +1,7 @@
 .dark
   // Core
   @import "./reset.dark"
+  @import "./icons.dark"
 
   // Display
   @import "./Abstract.dark"

--- a/packages/theme/lib/icons.dark.sass
+++ b/packages/theme/lib/icons.dark.sass
@@ -1,0 +1,2 @@
+.junipero-icons
+  --text-color: var(--junipero-seashell)

--- a/packages/theme/lib/icons.sass
+++ b/packages/theme/lib/icons.sass
@@ -1,3 +1,10 @@
+@font-face
+  font-family: 'junipero-icons'
+  src: url('https://cdn.junipero.design/icons/v1.0.0/junipero-icons.woff2?dtwlya') format('woff2')
+  font-weight: normal
+  font-style: normal
+  font-display: block
+
 .junipero.icon
   fill: none
 
@@ -6,3 +13,27 @@
     stroke-width: 2px
     stroke-linecap: round
     stroke-linejoin: round
+
+.junipero-icons
+  --text-color: var(--junipero-onyx)
+
+  /* use !important to prevent issues with browser extensions that change fonts */
+  font-family: 'junipero-icons' !important
+  font-size: 24px
+  speak: never
+  font-style: normal
+  font-weight: normal
+  font-variant: normal
+  text-transform: none
+  line-height: 1
+  letter-spacing: 0
+  color: var(--text-color)
+  -webkit-font-feature-settings: "liga"
+  -moz-font-feature-settings: "liga=1"
+  -moz-font-feature-settings: "liga"
+  -ms-font-feature-settings: "liga" 1
+  font-feature-settings: "liga"
+  -webkit-font-variant-ligatures: discretionary-ligatures
+  font-variant-ligatures: discretionary-ligatures
+  -webkit-font-smoothing: antialiased
+  -moz-osx-font-smoothing: grayscale

--- a/packages/theme/lib/index.stories.js
+++ b/packages/theme/lib/index.stories.js
@@ -20,7 +20,14 @@ const icons = [
 ];
 
 export const all = () => (
-  <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '8px' }}>
+  <div
+    style={{
+      display: 'flex',
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: '8px',
+    }}
+  >
     { icons.map(icon => (
       <i key={icon} className="junipero-icons">{ icon }</i>
     )) }

--- a/packages/theme/lib/index.stories.js
+++ b/packages/theme/lib/index.stories.js
@@ -1,0 +1,28 @@
+export default { title: 'theme/Icons' };
+
+const icons = [
+  'delete', 'account_off', 'account', 'ad', 'add_circle', 'add_user', 'add',
+  'align_left', 'appearences', 'archive', 'arrow_down', 'arrow_up', 'metrics',
+  'block', 'bulb', 'check_circle', 'click', 'clock', 'close_circle', 'close',
+  'closed_lock', 'color', 'cols', 'computer', 'copy_file', 'copy', 'coupon',
+  'credit_card_off', 'credit_card', 'dark_mode', 'dashboard', 'date_field',
+  'delete_forever', 'diamond', 'discovery_pass', 'download', 'expand_less',
+  'expand_more', 'field_click', 'field_text', 'field_type', 'file', 'foldable',
+  'form', 'free_article', 'help_circle', 'image', 'info_circle', 'integration',
+  'light_mode', 'list', 'magic_wand', 'more', 'multiline', 'newsletter',
+  'notification', 'open_lock', 'ordered_list', 'password_field', 'pause', 'pen',
+  'phone', 'play_circle', 'play', 'redo', 'refresh', 'revenues', 'row',
+  'scenario', 'search', 'send', 'settings', 'stars', 'stats',
+  'subscription_journey', 'subscription_page', 'subscription', 'success',
+  'survey', 'switch', 'title', 'trigger', 'turnover', 'undo', 'unfold',
+  'upload', 'url', 'user_edit', 'user_remove', 'user_substract', 'user_valid',
+  'user', 'users', 'vertical_split', 'visibility_off', 'visibility',
+];
+
+export const all = () => (
+  <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '8px' }}>
+    { icons.map(icon => (
+      <i key={icon} className="junipero-icons">{ icon }</i>
+    )) }
+  </div>
+);


### PR DESCRIPTION
Implements the new Junipero Icons set.
NB: The "delete" icon only displays one bar instead of two due to an IcoMoon import issue. I'll update the icons on the cdn when the issue is fixed.

<img width="1459" alt="Capture d’écran 2023-03-15 à 17 28 21" src="https://user-images.githubusercontent.com/1873323/225376150-04e1673c-0afb-476b-9cd7-8a92775ce4a8.png">
