### PR TITLE
✨ feat(core): allow to use a callback inside mockState

### DIFF
--- a/packages/core/lib/core/index.js
+++ b/packages/core/lib/core/index.js
@@ -47,7 +47,8 @@ export const removeClass = (elmt, cls) => {
   }
 };
 
-export const mockState = (state, action) => ({ ...state, ...action });
+export const mockState = (state, action) => typeof action === 'function'
+  ? action(state) : ({ ...state, ...action });
 
 export const isUndefined = v => typeof v === 'undefined';
 

--- a/packages/core/lib/core/index.test.js
+++ b/packages/core/lib/core/index.test.js
@@ -121,6 +121,11 @@ describe('core', () => {
       expect(mockState({ foo: 'bar' }, { foo: 'test' }))
         .toMatchObject({ foo: 'test' });
     });
+
+    it('should allow to use a function to compute new state', () => {
+      expect(mockState({ foo: 'bar' }, state => ({ foo: state.foo + 'test' })))
+        .toMatchObject({ foo: 'bartest' });
+    });
   });
 
   describe('isNull(value)', () => {

--- a/packages/react/lib/index.test.js
+++ b/packages/react/lib/index.test.js
@@ -1,0 +1,116 @@
+import { useReducer } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { mockState } from '@junipero/core';
+import { useTimeout } from '@junipero/hooks';
+
+import TextField from './TextField';
+
+describe('mockState: inside react', () => {
+  it('should fail update the state correctly and return the old ' +
+    'state', async () => {
+    const Comp = () => {
+      const [state, dispatch] = useReducer(mockState, {
+        value: {
+          text: 'This is a test',
+          content: [],
+        },
+      });
+
+      useTimeout(() => {
+        dispatch({ value: { ...state.value, content: ['foo'] } });
+      }, 1, []);
+
+      const onTextChange = ({ value }) => {
+        dispatch({ value: { ...state.value, text: value } });
+      };
+
+      const onContentChange = () => {
+        dispatch({
+          value: { ...state.value, content: [...state.value.content, 'bar'] },
+        });
+      };
+
+      return (
+        <div>
+          <TextField
+            data-testid="Field"
+            value={state.value.text}
+            onChange={onTextChange}
+          />
+          <button onClick={onContentChange}>Add content</button>
+          <div>Text: { state.value.text }</div>
+          <div>Content: { state.value.content.join(', ') }</div>
+        </div>
+      );
+    };
+
+    const { container, unmount } = render(<Comp />);
+
+    fireEvent.change(screen.getByTestId('Field'),
+      { target: { value: 'This is a test 2' } });
+
+    await waitFor(() => screen.getByText('Content: foo'));
+    expect(container).toMatchSnapshot('With updated text field value');
+
+    fireEvent.click(screen.getByText('Add content'));
+
+    expect(container)
+      .toMatchSnapshot('With updated content but with old text value');
+
+    unmount();
+  });
+
+  it('should not fail update the state correctly and return the new ' +
+    'state when using mockState with a callback', async () => {
+    const Comp = () => {
+      const [state, dispatch] = useReducer(mockState, {
+        value: {
+          text: 'This is a test',
+          content: [],
+        },
+      });
+
+      useTimeout(() => {
+        dispatch(s => ({ value: { ...s.value, content: ['foo'] } }));
+      }, 1, []);
+
+      const onTextChange = ({ value }) => {
+        dispatch(s => ({ value: { ...s.value, text: value } }));
+      };
+
+      const onContentChange = () => {
+        dispatch(s => ({
+          value: { ...s.value, content: [...s.value.content, 'bar'] },
+        }));
+      };
+
+      return (
+        <div>
+          <TextField
+            data-testid="Field"
+            value={state.value.text}
+            onChange={onTextChange}
+          />
+          <button onClick={onContentChange}>Add content</button>
+          <div>Text: { state.value.text }</div>
+          <div>Content: { state.value.content.join(', ') }</div>
+        </div>
+      );
+    };
+
+    const { container, unmount } = render(<Comp />);
+
+    fireEvent.change(screen.getByTestId('Field'),
+      { target: { value: 'This is a test 2' } });
+
+    await waitFor(() => screen.getByText('Content: foo'));
+    expect(container).toMatchSnapshot('With updated text field value');
+
+    fireEvent.click(screen.getByText('Add content'));
+
+    expect(container)
+      .toMatchSnapshot('With updated content AND updated text field valud');
+
+    unmount();
+  });
+});

--- a/packages/react/lib/index.test.js.snap
+++ b/packages/react/lib/index.test.js.snap
@@ -1,0 +1,113 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mockState: inside react should fail update the state correctly and return the old state: With updated content but with old text value 1`] = `
+<div>
+  <div>
+    <div
+      class="junipero text-field dirty valid"
+    >
+      <input
+        class="field"
+        data-testid="Field"
+        type="text"
+        value="This is a test"
+      />
+    </div>
+    <button>
+      Add content
+    </button>
+    <div>
+      Text: 
+      This is a test
+    </div>
+    <div>
+      Content: 
+      foo, bar
+    </div>
+  </div>
+</div>
+`;
+
+exports[`mockState: inside react should fail update the state correctly and return the old state: With updated text field value 1`] = `
+<div>
+  <div>
+    <div
+      class="junipero text-field dirty valid"
+    >
+      <input
+        class="field"
+        data-testid="Field"
+        type="text"
+        value="This is a test"
+      />
+    </div>
+    <button>
+      Add content
+    </button>
+    <div>
+      Text: 
+      This is a test
+    </div>
+    <div>
+      Content: 
+      foo
+    </div>
+  </div>
+</div>
+`;
+
+exports[`mockState: inside react should not fail update the state correctly and return the new state when using mockState with a callback: With updated content AND updated text field valud 1`] = `
+<div>
+  <div>
+    <div
+      class="junipero text-field dirty valid"
+    >
+      <input
+        class="field"
+        data-testid="Field"
+        type="text"
+        value="This is a test 2"
+      />
+    </div>
+    <button>
+      Add content
+    </button>
+    <div>
+      Text: 
+      This is a test 2
+    </div>
+    <div>
+      Content: 
+      foo, bar
+    </div>
+  </div>
+</div>
+`;
+
+exports[`mockState: inside react should not fail update the state correctly and return the new state when using mockState with a callback: With updated text field value 1`] = `
+<div>
+  <div>
+    <div
+      class="junipero text-field dirty valid"
+    >
+      <input
+        class="field"
+        data-testid="Field"
+        type="text"
+        value="This is a test 2"
+      />
+    </div>
+    <button>
+      Add content
+    </button>
+    <div>
+      Text: 
+      This is a test 2
+    </div>
+    <div>
+      Content: 
+      foo
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This might have been a pain in the ass for quite some time without we even began to realize it.

The issue:
`mockState` updates the state using `{ ...oldState, ...newState }` and `useReducer()`. This works as intended for most cases, but the tricky part comes with complexe deep state, like when using [@p3ol/oak](https://github.com/p3ol/oak).
Updating the state with `dispatch({ value: { ...state.value, content } })` would often break the natural behavior of `useReducer` and react's renderer and would rollback changes to other fields when a field was being mutated.

The solution:
We ended-up allowing to pass a callback to `dispatch` inside `mockState` (just like `useState` does for the exact same reasons) to be able to use the current state value without secretly using the value from the previous render (as it is the case in the issue).
This transforms `dispatch({ value: { ...state.value, content } })` into `dispatch(s => ({ value: { ...s.value, content } }))` and allows to make use of a more deterministic current state value.

------

Discovered with @maximedasilva.