### PR TITLE
🐛 fix(react): fix typo in tab component's inner ref

### DIFF
--- a/packages/react/lib/Tab/index.js
+++ b/packages/react/lib/Tab/index.js
@@ -22,7 +22,7 @@ const Tab = forwardRef(({
         'tab',
         className,
       )}
-      ref={ref}
+      ref={innerRef}
     />
   );
 });


### PR DESCRIPTION
Use the `innerRef` instead of the forwarded one in the `<Tab />` component