### PR TITLE
🐛 fix: remove horizontal padding on stepper

### DIFF
--- a/packages/theme/lib/Stepper.sass
+++ b/packages/theme/lib/Stepper.sass
@@ -6,7 +6,7 @@
 
   display: flex
   justify-content: space-around
-  padding: 40px 50px
+  padding: 30px 0px
 
   .step
     display: flex


### PR DESCRIPTION
Avant:

![Screenshot 2023-06-28 at 18 20 00](https://github.com/p3ol/junipero/assets/43884154/57066439-da9a-4999-b920-cf8e9e4d7b8b)

Après:

![Screenshot 2023-06-28 at 18 20 30](https://github.com/p3ol/junipero/assets/43884154/7e291869-fa97-4b27-a9c6-e600ae84b1ba)
