### PR TITLE
🐛 fix(core): fix wrong colors type declaration

### DIFF
--- a/packages/core/lib/colors/index.d.ts
+++ b/packages/core/lib/colors/index.d.ts
@@ -1,4 +1,4 @@
-export declare interface COLORS {
+export declare const COLORS: {
   [key: string]: {
     DEFAULT?: string;
     hover?: string;
@@ -6,7 +6,7 @@ export declare interface COLORS {
     disabled?: string;
     background?: string;
   } | string;
-}
+};
 
 export type COLOR_PARSERS = Array<{
   parse: ((r: string, g: string, b: string, a?: string) => {


### PR DESCRIPTION
This PR fixes the type declaration for `COLORS` to prevent TypeScript compiler to only find the type and not the value.