### PR TITLE
🐛 fix(core): fix find deep method returning too early in some cases

### DIFF
--- a/packages/core/lib/core/index.js
+++ b/packages/core/lib/core/index.js
@@ -179,7 +179,11 @@ export const findDeep = (
       if (multiple) {
         res.push(...findDeep(d, cb, depth, multiple));
       } else {
-        return findDeep(d, cb, depth);
+        const res = findDeep(d, cb, depth);
+
+        if (res) {
+          return res;
+        }
       }
     } else if (cb(v)) {
       if (multiple) {

--- a/packages/core/lib/core/index.test.js
+++ b/packages/core/lib/core/index.test.js
@@ -437,6 +437,26 @@ describe('core', () => {
         .toBe('Item 1');
     });
 
+    it('should correctly find an element inside deep arrays 2', () => {
+      const arr = [
+        { title: 'Susbcribe', options: [
+          {
+            title: 'Susbcribe metrics',
+            value: 'subscribe.metrics',
+          },
+        ] },
+        { title: 'Access', options: [
+          { title: 'Access metrics', value: 'access.metrics' },
+        ] },
+        { title: 'Engage', options: [
+          { title: 'Engage metrics', value: 'engage.metrics' },
+        ] },
+      ];
+      const val = 'access.metrics';
+      expect(findDeep(arr, v => v?.value === val || v === val, v => v.options))
+        .toMatchObject({ title: 'Access metrics', value: 'access.metrics' });
+    });
+
     it('should correctly find multiple elements inside deep arrays', () => {
       const arr = [0, 1, [2, 3, [4, 5, [6, 7, [8, 9]]]]];
       expect(findDeep(arr, v => v % 2 === 0, v => v, true))

--- a/packages/react/lib/SelectField/index.stories.js
+++ b/packages/react/lib/SelectField/index.stories.js
@@ -24,7 +24,6 @@ export const controlled = () => {
     <SelectField
       value={value}
       placeholder="Type a name"
-      options={['Item 1', 'Item 2', { title: 'Item 3', value: 'item-3' }]}
       parseTitle={o => o?.title || o}
       parseValue={o => o?.value || o}
       onChange={field => setValue(field.value)}
@@ -54,6 +53,26 @@ export const multiple = () => (
     multiple={true}
     value={['Item 1', 'Item 2', 'Item 4']}
     options={[{ title: 'Group 1', options: ['Item 1', 'Item 2'] }, 'Item 3']}
+  />
+);
+
+export const multipleWithGroups = () => (
+  <SelectField
+    placeholder="Type a name"
+    multiple={true}
+    value={['access.metrics']}
+    parseTitle={o => o?.title ?? o}
+      { title: 'Susbcribe', options: [
+        {
+          title: 'Susbcribe metrics',
+          value: 'subscribe.metrics',
+        },
+        { title: 'Access metrics', value: 'access.metrics' },
+      ] },
+      { title: 'Engage', options: [
+        { title: 'Engage metrics', value: 'engage.metrics' },
+      ] },
+    ]}
   />
 );
 

--- a/packages/react/lib/SelectField/index.stories.js
+++ b/packages/react/lib/SelectField/index.stories.js
@@ -62,11 +62,15 @@ export const multipleWithGroups = () => (
     multiple={true}
     value={['access.metrics']}
     parseTitle={o => o?.title ?? o}
+    parseValue={o => o?.value ?? o}
+    options={[
       { title: 'Susbcribe', options: [
         {
           title: 'Susbcribe metrics',
           value: 'subscribe.metrics',
         },
+      ] },
+      { title: 'Access', options: [
         { title: 'Access metrics', value: 'access.metrics' },
       ] },
       { title: 'Engage', options: [


### PR DESCRIPTION
`return findDeep(d, cb, depth);` would sometimes exit the outer loop early without iterating over every values of initial array.

Added a test to cover this case

Added a story to cover this case. The select field correctly finds the option matching the initial value (note that `access.metrics` is the second option in the array of options)
![image](https://github.com/p3ol/junipero/assets/16649348/2dbcde45-62a5-41b0-8478-f430e639509f)
