### PR TITLE
✨ feat(react): handle list sort state from outside

### DIFF
--- a/packages/react/lib/List/index.test.tsx
+++ b/packages/react/lib/List/index.test.tsx
@@ -82,4 +82,78 @@ describe('<List />', () => {
 
     unmount();
   });
+
+  it('should allow to handle order state from outside', () => {
+    const Comp = () => {
+      const [order, setOrder] = useState<{
+        column: string | number;
+        asc?: boolean;
+      }>({ column: 'name', asc: false });
+
+      const [items, setItems] = useState([
+        { name: 'John', age: 25 },
+        { name: 'Jane', age: 30 },
+        { name: 'Jack', age: 20 },
+      ]);
+
+      const onOrder = (
+        { column, asc }: { asc?: boolean, column: string | number}
+      ) => {
+        setOrder({ column, asc });
+        setItems(it => [...it.sort((a, b) => {
+          const aVal = a[column as 'name' | 'age'];
+          const bVal = b[column as 'name' | 'age'];
+          const result = aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+
+          return asc ? result : -result;
+        })]);
+      };
+
+      return (
+        <List onOrder={onOrder} order={order}>
+          <ListColumn id="name">Name</ListColumn>
+          <ListColumn id="age">Age</ListColumn>
+
+          { items.map(item => (
+            <ListItem key={item.name} item={[item.name, item.age]} />
+          )) }
+        </List>
+      );
+    };
+
+    const { container, getByText, unmount } = render(<Comp />);
+
+    fireEvent.click(getByText('Name'));
+    expect(container).toMatchSnapshot();
+
+    unmount();
+  });
+
+  it('should allow to disable order on column', () => {
+    const Comp = () => {
+      const [items] = useState([
+        { name: 'John', age: 25 },
+        { name: 'Jane', age: 30 },
+        { name: 'Jack', age: 20 },
+      ]);
+
+      return (
+        <List onOrder={() => {}}>
+          <ListColumn id="name" orderable={false}>Name</ListColumn>
+          <ListColumn id="age">Age</ListColumn>
+
+          { items.map(item => (
+            <ListItem key={item.name} item={[item.name, item.age]} />
+          )) }
+        </List>
+      );
+    };
+
+    const { container, getByText, unmount } = render(<Comp />);
+
+    fireEvent.click(getByText('Name'));
+    expect(container).toMatchSnapshot();
+
+    unmount();
+  });
 });

--- a/packages/react/lib/List/index.test.tsx.snap
+++ b/packages/react/lib/List/index.test.tsx.snap
@@ -1,5 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<List /> should allow to disable order on column 1`] = `
+<div>
+  <table
+    class="junipero list"
+  >
+    <thead>
+      <tr>
+        <th>
+          <span
+            class="junipero secondary"
+          >
+            Name
+          </span>
+        </th>
+        <th>
+          <a
+            href="#"
+          >
+            <span
+              class="junipero secondary"
+            >
+              Age
+            </span>
+          </a>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          John
+        </td>
+        <td>
+          25
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Jane
+        </td>
+        <td>
+          30
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Jack
+        </td>
+        <td>
+          20
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`<List /> should allow to handle order state from outside 1`] = `
+<div>
+  <table
+    class="junipero list"
+  >
+    <thead>
+      <tr>
+        <th>
+          <a
+            href="#"
+          >
+            <span
+              class="junipero secondary"
+            >
+              Name
+            </span>
+            <svg
+              class="junipero icon arrow-up"
+              height="5"
+              viewBox="0 0 8 5"
+              width="8"
+            >
+              <path
+                d="M1 4L4 1L7 4"
+              />
+            </svg>
+          </a>
+        </th>
+        <th>
+          <a
+            href="#"
+          >
+            <span
+              class="junipero secondary"
+            >
+              Age
+            </span>
+          </a>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          Jack
+        </td>
+        <td>
+          20
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Jane
+        </td>
+        <td>
+          30
+        </td>
+      </tr>
+      <tr>
+        <td>
+          John
+        </td>
+        <td>
+          25
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`<List /> should allow to reorder content 1`] = `
 <div>
   <table

--- a/packages/react/lib/List/index.tsx
+++ b/packages/react/lib/List/index.tsx
@@ -32,6 +32,7 @@ export declare type ListRef = {
 
 export declare interface ListProps extends ComponentPropsWithRef<any> {
   columns?: Array<string | ListColumnObject>;
+  order?: { column: string | number; asc: boolean | null };
   onOrder?(order: { column: string | number; asc: boolean | null }): void;
   ref?: MutableRefObject<ListRef | undefined>;
 }

--- a/packages/react/lib/ListColumn/index.tsx
+++ b/packages/react/lib/ListColumn/index.tsx
@@ -14,6 +14,7 @@ import { useList } from '../hooks';
 export declare interface ListColumnObject {
   id?: string | number;
   title?: ReactNode | JSX.Element;
+  orderable?: boolean;
 }
 
 export declare type ListColumnRef = {
@@ -30,6 +31,7 @@ export declare interface ListColumnProps extends ComponentPropsWithRef<any> {
 const ListColumn = forwardRef(({
   id,
   children,
+  orderable = true,
   ...rest
 }: ListColumnProps, ref) => {
   const { registerColumn } = useList();
@@ -46,7 +48,7 @@ const ListColumn = forwardRef(({
       return;
     }
 
-    registerColumn({ id, title: children, ...rest });
+    registerColumn({ id, title: children, orderable, ...rest });
   }, []);
 
   return null;

--- a/packages/react/lib/contexts.tsx
+++ b/packages/react/lib/contexts.tsx
@@ -13,48 +13,48 @@ export type AlertsContextType = {
 }
 
 export type DropdownContextType = {
-  opened?: boolean,
-  visible?: boolean,
-  container?: string | JSX.Element | DocumentFragment | HTMLElement,
-  x?: number,
-  y?: number,
-  refs?: ExtendedRefs<any>,
-  strategy?: Strategy,
-  toggle?: () => void,
-  open?: () => void,
-  close?: () => void,
+  opened?: boolean;
+  visible?: boolean;
+  container?: string | JSX.Element | DocumentFragment | HTMLElement;
+  x?: number;
+  y?: number;
+  refs?: ExtendedRefs<any>;
+  strategy?: Strategy;
+  toggle?: () => void;
+  open?: () => void;
+  close?: () => void;
   getReferenceProps?: (
     userProps?: React.HTMLProps<Element>
-  ) => Record<string, unknown>,
+  ) => Record<string, unknown>;
   getFloatingProps?: (
     userProps?: React.HTMLProps<HTMLElement>
-  ) => Record<string, unknown>,
-  onAnimationExit?: () => void,
+  ) => Record<string, unknown>;
+  onAnimationExit?: () => void;
 }
 
-export type ListContextType= {
-  active?: string | number,
-  asc?: boolean,
-  orderable?: boolean,
-  registerColumn?: (column: string | ListColumnObject) => void
+export type ListContextType = {
+  active?: string | number;
+  asc?: boolean;
+  orderable?: boolean;
+  registerColumn?: (column: string | ListColumnObject) => void;
 }
 
 export type FieldContextType = {
-  valid?: boolean,
-  dirty?: boolean,
-  focused?: boolean,
-  update?: Dispatch<any>,
+  valid?: boolean;
+  dirty?: boolean;
+  focused?: boolean;
+  update?: Dispatch<any>;
 }
 
 export type ToastsContextType = {
-  toasts?: Array<ToastObject>,
-  add?: (toas: ToastObject) => void,
-  dismiss?: (toast: ToastObject) => void,
+  toasts?: Array<ToastObject>;
+  add?: (toas: ToastObject) => void;
+  dismiss?: (toast: ToastObject) => void;
 }
 export declare interface ModalContextType {
   open?(): void;
   close?(): void;
-  toggle?: any,
+  toggle?: any;
   setRef?: (ref: ModalRef) => void;
 }
 


### PR DESCRIPTION
This PR adds ability to handle the list's sort state from outside the component to allow things like pre-sorting. It also adds a new prop to disable sorting on specific column so you can choose which column is sortable.