### PR TITLE
🐛 fix(react-d3-plugin): remove function as a way to define axis type and scale

### DIFF
--- a/packages/react-d3-plugin/lib/Axis/index.tsx
+++ b/packages/react-d3-plugin/lib/Axis/index.tsx
@@ -11,7 +11,7 @@ import { type JuniperoRef, classNames } from '@junipero/react';
 import * as d3 from 'd3';
 
 import { useChart } from '../hooks';
-import { getAxisType } from '../utils';
+import { getAxisType, getAxisFunction } from '../utils';
 
 export declare type AxisDataType = Array<
   | string
@@ -23,9 +23,8 @@ export declare type AxisDataType = Array<
 >;
 
 export declare interface AxisObject<T = AxisDataType> {
-  type: typeof d3.axisLeft | typeof d3.axisBottom | typeof d3.axisRight |
-    typeof d3.axisTop;
-  scale: typeof d3.scaleLinear | typeof d3.scaleTime | typeof d3.scaleBand;
+  type: 'axisTop' | 'axisRight' | 'axisBottom' | 'axisLeft';
+  scale: 'scaleLinear' | 'scaleTime' | 'scaleBand';
   data: T;
   range?: d3.ScaleContinuousNumeric<number, number> |
     d3.ScaleLinear<number, number> |
@@ -87,9 +86,9 @@ const Axis = forwardRef<AxisRef, AxisProps>(({
     }
 
     switch (axis.type) {
-      case d3.axisLeft: return [0, 0];
-      case d3.axisRight: return [width - paddingRight - paddingLeft, 0];
-      case d3.axisTop: return [0, 0];
+      case 'axisLeft': return [0, 0];
+      case 'axisRight': return [width - paddingRight - paddingLeft, 0];
+      case 'axisTop': return [0, 0];
       default: return [-paddingLeft, height - paddingTop - paddingBottom];
     }
   }, [
@@ -109,7 +108,7 @@ const Axis = forwardRef<AxisRef, AxisProps>(({
 
     d3
       .select(ticksRef.current)
-      .call(axis.type(axis.range)
+      .call(getAxisFunction(axis.type)(axis.range)
         .ticks(axis.ticks ?? 5)
         .tickSize(axis.tickSize ?? 5)
         .tickFormat((d: Date | number) => (
@@ -121,7 +120,7 @@ const Axis = forwardRef<AxisRef, AxisProps>(({
     if (axis.grid) {
       d3
         .select(gridRef.current)
-        .call(axis.type(axis.range)
+        .call(getAxisFunction(axis.type)(axis.range)
           .ticks(axis.ticks ?? 5)
           .tickSize(-(width - paddingLeft - paddingRight))
           .tickFormat((d: Date | number) => '') as any,

--- a/packages/react-d3-plugin/lib/Chart/index.stories.tsx
+++ b/packages/react-d3-plugin/lib/Chart/index.stories.tsx
@@ -40,24 +40,24 @@ const axis: [
     AxisObject<Array<number>>,
     AxisObject<Array<number>>
 ] = [{
-  type: d3.axisBottom,
-  scale: d3.scaleTime,
+  type: 'axisBottom',
+  scale: 'scaleTime',
   data: data.map(d => d[0]),
   findSelectionIndex: (position: Date) =>
     closestIndexTo(position, data.map(d => d[0])),
   parseTitle: (d: Date) => d.toLocaleDateString(),
   ticks: null,
 }, {
-  type: d3.axisLeft,
-  scale: d3.scaleLinear,
+  type: 'axisLeft',
+  scale: 'scaleLinear',
   data: data.map(d => d[1]),
   grid: true,
   min: 0,
   tickSize: 20,
   parseTitle: d => `${d}%`,
 }, {
-  type: d3.axisRight,
-  scale: d3.scaleLinear,
+  type: 'axisRight',
+  scale: 'scaleLinear',
   data: alternativeData.map(d => d[1]),
   tickSize: 20,
   min: 0,
@@ -67,14 +67,14 @@ const barAxis: [
   AxisObject<Array<Date>>,
   AxisObject<Array<{ premium: number, free: number }>>
 ] = [{
-  type: d3.axisBottom,
-  scale: d3.scaleBand,
+  type: 'axisBottom',
+  scale: 'scaleBand',
   data: barData.map(d => d[0]) as any,
   parseTitle: (d: Date) => d?.toLocaleDateString(),
   ticks: null,
 }, {
-  type: d3.axisLeft,
-  scale: d3.scaleLinear,
+  type: 'axisLeft',
+  scale: 'scaleLinear',
   grid: true,
   min: 0,
   max: 100,

--- a/packages/react-d3-plugin/lib/Chart/index.test.tsx
+++ b/packages/react-d3-plugin/lib/Chart/index.test.tsx
@@ -22,8 +22,8 @@ describe('<Chart />', () => {
         width={1000}
         height={500}
         axis={[{
-          type: d3.axisBottom,
-          scale: d3.scaleTime,
+          type: 'axisBottom',
+          scale: 'scaleTime',
           data: [
             new Date('2020-10-01T00:00:00.000Z'),
             new Date('2020-10-02T00:00:00.000Z'),
@@ -31,8 +31,8 @@ describe('<Chart />', () => {
           parseTitle: (d: Date) => d.toISOString(),
           ticks: null,
         }, {
-          type: d3.axisLeft,
-          scale: d3.scaleLinear,
+          type: 'axisLeft',
+          scale: 'scaleLinear',
           data: [0, 100],
           grid: true,
           min: 0,

--- a/packages/react-d3-plugin/lib/Chart/index.tsx
+++ b/packages/react-d3-plugin/lib/Chart/index.tsx
@@ -80,28 +80,28 @@ const Chart = forwardRef<ChartRef, ChartProps>(({
       ReturnType<typeof d3.scaleBand>;
 
     switch (a.scale) {
-      case d3.scaleTime:
+      case 'scaleTime':
         domain = d3.scaleTime().domain(d3.extent(d3.timeDay.range(
           startOfDay(a.min ?? d3.min(a.data as Date[])),
           endOfDay(a.max ?? d3.max(a.data as Date[])),
           1
         )));
         break;
-      case d3.scaleLinear:
-        domain = a.scale().domain([
+      case 'scaleLinear':
+        domain = d3.scaleLinear().domain([
           a.min as number ?? d3.min(a.data as number[]),
           (a.max as number ?? d3.max(a.data as number[])) *
             linearDomainMaxMargin,
         ]);
         break;
-      case d3.scaleBand:
-        domain = (a.scale() as ReturnType<typeof d3.scaleBand>)
+      case 'scaleBand':
+        domain = (d3.scaleBand() as ReturnType<typeof d3.scaleBand>)
           .domain(a.data)
           .paddingInner(bandDomainInnerPadding)
           .paddingOuter(bandDomainOuterPadding);
         break;
       default:
-        domain = (a.scale as typeof d3.scaleLinear)().domain([
+        domain = d3.scaleLinear().domain([
           a.min ?? d3.min(a.data as number[]),
           a.max ?? d3.max(a.data as number[]),
         ]);
@@ -110,8 +110,8 @@ const Chart = forwardRef<ChartRef, ChartProps>(({
     let range: ReturnType<typeof domain.range>;
 
     switch (a.type) {
-      case d3.axisBottom:
-      case d3.axisTop:
+      case 'axisBottom':
+      case 'axisTop':
         range = domain.range([
           state.paddingLeft,
           state.width - state.paddingRight,

--- a/packages/react-d3-plugin/lib/Curve/index.tsx
+++ b/packages/react-d3-plugin/lib/Curve/index.tsx
@@ -106,7 +106,7 @@ const Curve = forwardRef<CurveRef, CurveProps>(({
       .curve(curve).x((d, i) => isMonoData
         ? Math
           .min(width - paddingRight - paddingLeft, i * width) - lineCapShift
-        : xAxis.range(xAxis.scale === d3.scaleTime
+        : xAxis.range(xAxis.scale === 'scaleTime'
           ? startOfDay(d[0])
           : d[0]
         ) - paddingLeft - lineCapShift
@@ -145,7 +145,7 @@ const Curve = forwardRef<CurveRef, CurveProps>(({
         .x((d, i) => isMonoData
           ? Math
             .min(width - paddingRight - paddingLeft, i * width) - lineCapShift
-          : xAxis.range(xAxis.scale === d3.scaleTime
+          : xAxis.range(xAxis.scale === 'scaleTime'
             ? startOfDay(d[0])
             : d[0]
           ) - paddingLeft - lineCapShift
@@ -191,7 +191,7 @@ const Curve = forwardRef<CurveRef, CurveProps>(({
           transform={
             'translate(' +
               (
-                (xAxis?.range?.(xAxis.scale === d3.scaleTime
+                (xAxis?.range?.(xAxis.scale === 'scaleTime'
                   ? startOfDay(selected[0])
                   : selected[0]
                 ) || 0) - paddingLeft - lineCapShift

--- a/packages/react-d3-plugin/lib/Marker/index.tsx
+++ b/packages/react-d3-plugin/lib/Marker/index.tsx
@@ -82,7 +82,7 @@ const Marker = forwardRef<MarkerRef, MarkerProps>(({
     ).invert(cursor.x);
 
     const xIndex = axis[xAxisIndex]?.findSelectionIndex?.(position);
-    const xValue = xAxis?.domain?.(xAxis.scale === d3.scaleTime
+    const xValue = xAxis?.domain?.(xAxis.scale === 'scaleTime'
       ? startOfDay(xAxis?.data?.[xIndex] as Date)
       : xAxis?.data?.[xIndex] as number);
     const yValue = Math.min(...(series

--- a/packages/react-d3-plugin/lib/utils.ts
+++ b/packages/react-d3-plugin/lib/utils.ts
@@ -1,15 +1,24 @@
 import * as d3 from 'd3';
 
 export const getAxisType = (
-  type: typeof d3.axisLeft
-    | typeof d3.axisRight
-    | typeof d3.axisTop
+  type: 'axisLeft' | 'axisRight' | 'axisTop' | 'axisBottom'
 ) => {
   switch (type) {
-    case d3.axisLeft: return 'left';
-    case d3.axisRight: return 'right';
-    case d3.axisTop: return 'top';
+    case 'axisLeft': return 'left';
+    case 'axisRight': return 'right';
+    case 'axisTop': return 'top';
     default: return 'bottom';
+  }
+};
+
+export const getAxisFunction = (
+  type: 'axisLeft' | 'axisRight' | 'axisTop' | 'axisBottom'
+) => {
+  switch (type) {
+    case 'axisLeft': return d3.axisLeft;
+    case 'axisRight': return d3.axisRight;
+    case 'axisTop': return d3.axisTop;
+    default: return d3.axisBottom;
   }
 };
 


### PR DESCRIPTION
This PR changes the way to define axis's type and scale. Using a D3 function to set the type and scale could be problematic because we often perform equality checks on these functions and if the function ever goes through a bundler, the reference may me removed. So we replaced this wobbly system with a simple definition via a string.

Before : 
```jsx
    <Chart
      axis={[{
        type: d3.axisBottom,
        scale: d3.scaleTime,
      }, {
        type: d3.axisRight,
        scale: d3.scaleLinear,
      }]}
    >
      <Curve
        type="area"
        xAxisIndex={0}
        yAxisIndex={1}
      />
    </Chart>
```

After : 
```jsx
    <Chart
      axis={[{
        type: 'axisBottom',
        scale: 'scaleTime',
      }, {
        type: 'axisRight',
        scale: 'scaleLinear',
      }]}
    >
      <Curve
        type="area"
        xAxisIndex={0}
        yAxisIndex={1}
      />
    </Chart>
```