### PR TITLE
🐛 fix(react): do not display options when noOptions is disabled & search results are empty

### DIFF
--- a/packages/react/lib/SelectField/index.tsx
+++ b/packages/react/lib/SelectField/index.tsx
@@ -607,7 +607,7 @@ const SelectField = forwardRef<SelectFieldRef, SelectFieldProps>(({
           </div>
         </div>
       </DropdownToggle>
-      { (hasOptions || noOptionsEnabled || state.searchResults) && (
+      { (hasOptions || state.searchResults?.length > 0 || noOptionsEnabled) && (
         <DropdownMenu
           animate={animateMenu}
           className={classNames('select-menu', { searching: state.searching })}


### PR DESCRIPTION
If search results array is empty but set, and even if noOptionsEnabled is set to `false`, the dropdown is displayed.