### PR TITLE
📦chore: add renovate support for legacy/v2 branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "p3ol/renovate-presets//presets/base#v1.1.0",
     "p3ol/renovate-presets//presets/master-develop#v1.1.0"
   ],
+  "baseBranchPattern": ["master", "legacy/v2"],
   "packageRules": [{
     "matchUpdateTypes": ["patch", "pin"],
     "matchDepTypes": ["devDependencies", "dependencies"],


### PR DESCRIPTION
To help us to being updated with our dependancies on `legacy/v2` branch that represents the old junipero design