### PR TITLE
🐛 fix(color-field): missing disabled state on base field

### DIFF
--- a/packages/react/lib/ColorField/index.stories.tsx
+++ b/packages/react/lib/ColorField/index.stories.tsx
@@ -41,3 +41,7 @@ export const AlwaysOpened = () => (
 export const Animated = () => (
   <ColorField animateMenu={slideInDownMenu} />
 );
+
+export const Disabled = () => (
+  <ColorField animateMenu={slideInDownMenu} disabled={true} />
+);

--- a/packages/react/lib/ColorField/index.tsx
+++ b/packages/react/lib/ColorField/index.tsx
@@ -433,6 +433,7 @@ const ColorField = ({
               onFocus={onFocus_}
               onBlur={onBlur_}
               onChange={onChange_}
+              disabled={disabled}
               tabIndex={tabIndex}
               valid={state.valid || !state.dirty || state.opened}
             />


### PR DESCRIPTION
Providing the `disabled` property was only locking the dropdown & menu, but the field was still available.