### PR TITLE
🐛 fix(theme): correctly set z-index property on opened only fields inside field group

### DIFF
--- a/packages/theme/lib/FieldGroup.sass
+++ b/packages/theme/lib/FieldGroup.sass
@@ -59,7 +59,8 @@
       &:not(:disabled):not(.disabled)
         box-shadow: 0 0 0 2px var(--active-color)
 
-  .junipero.focused
+  .junipero.focused,
+  .junipero.opened
     z-index: 3
 
   .junipero .pigment


### PR DESCRIPTION
For some reason, inside a field group, fields with a value + a menu opened are not considered as focused. In this special case, the z-index is only 2 instead of 3 so it causes overlap issues. This PR increases the z-index to 3 on opened fields.

Before : 

https://github.com/user-attachments/assets/d436a4cd-2ab9-419d-930c-8530307814a0

After : 

https://github.com/user-attachments/assets/7e1ee7a0-8599-4a55-b540-43b891ddd68b

